### PR TITLE
CHILDPAGES-7 : Invalidate childpages portlets when a page is reparented

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>fr.paris.lutece</groupId>
             <artifactId>lutece-core</artifactId>
-            <version>[2.3.0,)</version>
+            <version>[5.0.1-SNAPSHOT,)</version>
             <type>lutece-core</type>
         </dependency>
     </dependencies>

--- a/src/java/fr/paris/lutece/plugins/childpages/business/portlet/EventListener.java
+++ b/src/java/fr/paris/lutece/plugins/childpages/business/portlet/EventListener.java
@@ -33,6 +33,7 @@
  */
 package fr.paris.lutece.plugins.childpages.business.portlet;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import fr.paris.lutece.portal.business.page.Page;
@@ -93,26 +94,35 @@ public class EventListener implements PageEventListener
                 // we reached the root
                 return;
             }
-            // invalidate portlets with the default parent page
-            Page parentPage = PageHome.findByPrimaryKey( parentPageId );
-            List<Portlet> portlets = parentPage.getPortlets( );
-            String childPagesPortletId = ChildPagesPortletHome.getInstance( ).getPortletTypeId( );
-            for ( Portlet aPortlet : portlets )
+            List<Integer> parentPageIds = new ArrayList<Integer>( 2 );
+            parentPageIds.add( parentPageId );
+            if ( parentPageId != event.getPage( ).getOrigParentPageId( ) )
             {
-                if ( aPortlet.getPortletTypeId( ).equals( childPagesPortletId ) )
+                parentPageIds.add( event.getPage( ).getOrigParentPageId( ) );
+            }
+            for ( Integer pageId : parentPageIds )
+            {
+                // invalidate portlets with the default parent page
+                Page parentPage = PageHome.findByPrimaryKey( pageId );
+                List<Portlet> portlets = parentPage.getPortlets( );
+                String childPagesPortletId = ChildPagesPortletHome.getInstance( ).getPortletTypeId( );
+                for ( Portlet aPortlet : portlets )
                 {
-                    ChildPagesPortlet cpPortlet = ( ChildPagesPortlet ) aPortlet;
-                    if ( cpPortlet.getParentPageId( ) == 0 )
+                    if ( aPortlet.getPortletTypeId( ).equals( childPagesPortletId ) )
                     {
-                        PortletHome.invalidate( aPortlet );
+                        ChildPagesPortlet cpPortlet = ( ChildPagesPortlet ) aPortlet;
+                        if ( cpPortlet.getParentPageId( ) == 0 )
+                        {
+                            PortletHome.invalidate( aPortlet );
+                        }
                     }
                 }
-            }
-            // invalidate portlets with custom parent page 
-            List<ChildPagesPortlet> childPagesportlets = ChildPagesPortletHome.getChildPagesPortlets( parentPageId );
-            for ( ChildPagesPortlet aPortlet : childPagesportlets )
-            {
-                PortletHome.invalidate( aPortlet );
+                // invalidate portlets with custom parent page
+                List<ChildPagesPortlet> childPagesportlets = ChildPagesPortletHome.getChildPagesPortlets( pageId );
+                for ( ChildPagesPortlet aPortlet : childPagesportlets )
+                {
+                    PortletHome.invalidate( aPortlet );
+                }
             }
         } finally
         {

--- a/src/test/java/fr/paris/lutece/plugins/childpages/business/portlet/EventListenerTest.java
+++ b/src/test/java/fr/paris/lutece/plugins/childpages/business/portlet/EventListenerTest.java
@@ -294,7 +294,7 @@ public class EventListenerTest extends LuteceTestCase
     private static final String PORLET_NAME = "ChildPagesPortletTest";
 
     @Before
-    public void createPortlet( ) throws Exception
+    public void setUp( ) throws Exception
     {
         super.setUp( );
         ChildPagesPortlet portlet = new ChildPagesPortlet( );
@@ -314,7 +314,7 @@ public class EventListenerTest extends LuteceTestCase
     }
 
     @After
-    public void destroyPortlet( ) throws Exception
+    public void tearDown( ) throws Exception
     {
         ChildPagesPortlet portlet = findTestPortlet( );
         if ( portlet != null )


### PR DESCRIPTION
Bump the dependency on core to have access to the original parent page ID.
Update the tests to cope with dependency changes.

depends on https://github.com/lutece-platform/lutece-core/pull/19
